### PR TITLE
Add a tasks page which displays available Hangfire tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.1.300
+dotnet: 2.1.502
 dist: trusty
 os:
   - linux

--- a/Hangfire.Contrib.sln
+++ b/Hangfire.Contrib.sln
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Webenable.Hangfire.Contrib"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{087E1B64-FA04-4883-8300-191539D43BDE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Webenable.Hangfire.Contrib.Tests", "test\Webenable.Hangfire.Contrib.Tests\Webenable.Hangfire.Contrib.Tests.csproj", "{8EAAEA35-FC4F-41FD-AA24-0C9C86996949}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Webenable.Hangfire.Contrib.Tests", "test\Webenable.Hangfire.Contrib.Tests\Webenable.Hangfire.Contrib.Tests.csproj", "{8EAAEA35-FC4F-41FD-AA24-0C9C86996949}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Webenable.Hangfire.Contrib.TestApp", "test\Webenable.Hangfire.Contrib.TestApp\Webenable.Hangfire.Contrib.TestApp.csproj", "{785B1994-B5A7-404C-B3DE-84705BEB9EFC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +47,18 @@ Global
 		{8EAAEA35-FC4F-41FD-AA24-0C9C86996949}.Release|x64.Build.0 = Release|Any CPU
 		{8EAAEA35-FC4F-41FD-AA24-0C9C86996949}.Release|x86.ActiveCfg = Release|Any CPU
 		{8EAAEA35-FC4F-41FD-AA24-0C9C86996949}.Release|x86.Build.0 = Release|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Debug|x64.Build.0 = Debug|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Debug|x86.Build.0 = Debug|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Release|x64.ActiveCfg = Release|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Release|x64.Build.0 = Release|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Release|x86.ActiveCfg = Release|Any CPU
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,6 +66,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{49B54C74-8F83-450A-8A65-C4C67962D846} = {723AD819-250C-49A2-8544-017EE4A009D7}
 		{8EAAEA35-FC4F-41FD-AA24-0C9C86996949} = {087E1B64-FA04-4883-8300-191539D43BDE}
+		{785B1994-B5A7-404C-B3DE-84705BEB9EFC} = {087E1B64-FA04-4883-8300-191539D43BDE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B5948FEB-F42A-48D1-9EB9-3B183059A48F}

--- a/src/Webenable.Hangfire.Contrib/HangfireTaskRegister.cs
+++ b/src/Webenable.Hangfire.Contrib/HangfireTaskRegister.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Webenable.Hangfire.Contrib
+{
+    public static class HangfireTaskRegister
+    {
+        private static readonly Dictionary<string, HangfireTaskDefinition> _tasks = new Dictionary<string, HangfireTaskDefinition>();
+
+        public static IReadOnlyDictionary<string, HangfireTaskDefinition> Tasks => new ReadOnlyDictionary<string, HangfireTaskDefinition>(_tasks);
+
+        /// <summary>
+        /// Adds the specified method of the task to the Hangfire task register.
+        /// </summary>
+        /// <typeparam name="TTask">The type of the task.</typeparam>
+        /// <param name="expression">An expression which represents the method call to invoke the task.</param>
+        public static void AddTask<TTask>(Expression<Func<TTask, object>> expression)
+        {
+            if (expression == null)
+            {
+                throw new ArgumentNullException(nameof(expression));
+            }
+            if (!(expression.Body is MethodCallExpression methodCall))
+            {
+                throw new ArgumentException("Specified expression is not a valid method call expression.", nameof(expression));
+            }
+
+            // Create a Hangfire task instance from the method call
+            var method = methodCall.Method;
+            var task = new HangfireTaskDefinition
+            {
+                Type = typeof(TTask),
+                Method = method,
+                // Add each simple parameter to the task definition
+                Parameters = method
+                    .GetParameters()
+                    .Where(p => IsSimple(p.ParameterType))
+                    .Select(p => new HangfireTaskParameter { Name = p.Name, Type = p.ParameterType }).ToArray()
+            };
+
+            _tasks[task.Type.Name] = task;
+
+            bool IsSimple(Type type)
+            {
+                type = Nullable.GetUnderlyingType(type) ?? type;
+                return type.IsPrimitive
+                  || type.IsEnum
+                  || type.Equals(typeof(string))
+                  || type.Equals(typeof(decimal));
+            }
+        }
+    }
+
+    public class HangfireTaskDefinition
+    {
+        public Type Type { get; set; }
+
+        public MethodInfo Method { get; set; }
+
+        public HangfireTaskParameter[] Parameters { get; set; }
+    }
+
+    public class HangfireTaskParameter
+    {
+        public string Name { get; set; }
+
+        public Type Type { get; set; }
+    }
+}

--- a/src/Webenable.Hangfire.Contrib/Internal/HangfireTasks.cshtml
+++ b/src/Webenable.Hangfire.Contrib/Internal/HangfireTasks.cshtml
@@ -1,0 +1,95 @@
+﻿@{
+    var tasks = Webenable.Hangfire.Contrib.HangfireTaskRegister.Tasks.Values;
+}
+<div class="row">
+    <div class="col-md-12">
+        <h1 class="page-header">Tasks</h1>
+        @if (!tasks.Any())
+        {
+            <div class="alert alert-info">
+                No tasks registered.
+            </div>
+        }
+        else
+        {
+            @foreach (var task in tasks)
+            {
+                <div class="panel panel-default" style="max-width: 70rem">
+                    <div class="panel-heading">
+                        @task.Type.Name
+                    </div>
+                    <div class="panel-body">
+                        <form class="form-horizontal" action="tasks/trigger/@task.Type.Name" method="post">
+                            @foreach (var param in task.Parameters)
+                            {
+                                <div class="form-group">
+                                    <label for="@task.Type.Name-@param.Name" class="col-sm-3 control-label">@param.Name (<code>@param.Type.Name</code>)</label>
+                                    <div class="col-sm-9">
+                                        @if (param.Type == typeof(int))
+                                        {
+                                            <input type="number"
+                                                   class="form-control"
+                                                   id="@task.Type.Name-@param.Name"
+                                                   name="@param.Name"
+                                                   placeholder="@param.Name"
+                                                   required />
+                                        }
+                                        @if (param.Type == typeof(string))
+                                        {
+                                            <textarea class="form-control"
+                                                      id="@task.Type.Name-@param.Name"
+                                                      name="@param.Name"
+                                                      placeholder="@param.Name"
+                                                      required></textarea>
+                                        }
+                                    </div>
+                                </div>
+                            }
+
+                            <div class="pull-right">
+                                <button name="trigger-job"
+                                        onclick="trigger(this)"
+                                        class="btn btn-primary"
+                                        data-ajax="tasks/trigger/@task.Type.Name"
+                                        data-loading-text="Triggering...">
+                                    Trigger
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            }
+        }
+    </div>
+</div>
+<script type="text/javascript">
+    function trigger(el) {
+        var $button = $(el);
+        var $form = $button.closest('form');
+
+        // Validate the form
+        if (!$form[0].checkValidity()) {
+            $form[0].reportValidity();
+            console.warn('Invalid form', $form[0]);
+
+            // Prevent the Hangfire event handler to fire which would trigger the task
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            return;
+        }
+
+        // Get the data from each field on the form and aggregate it into a single variable
+        var args = '';
+        $form.find('.form-control').each(function (i, e) {
+            var val = $(e).val();
+            if (val) {
+                args += val + ';';
+            }
+        });
+
+        // Replace the data-ajax attribute on the button which Hangfire uses to
+        // POST to the server with a URL including the task arguments
+        args = args.substring(0, args.length - 1);
+        $button.data('ajax', $button.data('ajax') + '/' + encodeURIComponent(args));
+    }
+</script>

--- a/src/Webenable.Hangfire.Contrib/Internal/HangfireTasksPage.cs
+++ b/src/Webenable.Hangfire.Contrib/Internal/HangfireTasksPage.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using System.Text;
+using Hangfire.Dashboard.Pages;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Internal;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Webenable.Hangfire.Contrib.Internal
+{
+    internal class HangfireTasksPage : global::Hangfire.Dashboard.RazorPage
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public HangfireTasksPage(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public override void Execute()
+        {
+            Layout = new LayoutPage("Tasks");
+
+            // Resolve HttpContext and the service provider
+            var httpContext = _httpContextAccessor.HttpContext;
+            var sp = httpContext.RequestServices;
+
+            // Find and create the Razor page instance
+            var pageFactoryProvider = sp.GetRequiredService<IRazorPageFactoryProvider>();
+            var pageActivator = sp.GetRequiredService<IRazorPageActivator>();
+            var factoryResult = pageFactoryProvider.CreateFactory(ViewEnginePath.ResolvePath("~/Internal/HangfireTasks.cshtml"));
+            var page = factoryResult.RazorPageFactory.Invoke();
+
+            var sb = new StringBuilder();
+            using (var writer = new StringWriter(sb))
+            {
+                // Create a view context with the in-memory string writer and assign it to the page
+                var viewContext = new ViewContext
+                {
+                    HttpContext = httpContext,
+                    Writer = writer
+                };
+                page.ViewContext = viewContext;
+
+                // Actives the necessary properties on the Razor page
+                pageActivator.Activate(page, viewContext);
+
+                // Render the page (synchronously...)
+                page.ExecuteAsync().GetAwaiter().GetResult();
+            }
+
+            // Write the HTML output to the Razor page of Hangfire
+            WriteLiteral(sb.ToString());
+        }
+    }
+}

--- a/src/Webenable.Hangfire.Contrib/Internal/HangfireTasksStartupFilter.cs
+++ b/src/Webenable.Hangfire.Contrib/Internal/HangfireTasksStartupFilter.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Linq;
+using Hangfire.Common;
+using Hangfire.Dashboard;
+using Hangfire.States;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Webenable.Hangfire.Contrib.Internal
+{
+    public class HangfireTasksStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+        {
+            // Add a route to a custom Razor page
+            var httpContextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
+            DashboardRoutes.Routes.AddRazorPage("/tasks", _ => new HangfireTasksPage(httpContextAccessor));
+
+            // Add a route to handle the trigger command
+            DashboardRoutes.Routes.AddCommand("/tasks/trigger/(?<TaskName>.+)/(?<Args>.+)", ctx =>
+            {
+                var taskName = ctx.UriMatch.Groups["TaskName"].Value;
+                if (HangfireTaskRegister.Tasks.TryGetValue(taskName, out var task))
+                {
+                    // Extract the job arguments from the URL
+                    var urlArgs = ctx.UriMatch.Groups["Args"].Value;
+                    var args = urlArgs.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    // Create a job instance and trigger it
+                    var client = ctx.GetBackgroundJobClient();
+
+                    if (task.Method.GetParameters().Length != args.Length)
+                    {
+                        // Append default values for remaining parameters
+                        // For example, pass null for the PerformContext and JobCancellationToken
+                        args = args.Concat(Enumerable.Repeat<string>(null, task.Method.GetParameters().Length - args.Length)).ToArray();
+                    }
+
+                    client.Create(new Job(task.Method, args), new EnqueuedState());
+                    return true;
+                }
+
+                return false;
+            });
+
+            // Add a navigation item to the Hangfire dashboard menu
+            NavigationMenu.Items.Add(page => new MenuItem("Tasks", page.Url.To("/tasks"))
+            {
+                Active = page.RequestPath.Equals("/tasks"),
+                Metric = new DashboardMetric("Tasks", _ => new Metric(HangfireTaskRegister.Tasks.Count))
+            });
+            next(app);
+        };
+    }
+}

--- a/src/Webenable.Hangfire.Contrib/TasksPageServiceCollectionExtensions.cs
+++ b/src/Webenable.Hangfire.Contrib/TasksPageServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Webenable.Hangfire.Contrib.Internal;
+
+namespace Webenable.Hangfire.Contrib
+{
+    public static class TasksPageServiceCollectionExtensions
+    {
+        public static IServiceCollection AddHangfireTasksPage(this IServiceCollection services)
+        {
+            services.AddHttpContextAccessor();
+            services.AddMvcCore()
+                .AddRazorViewEngine(o => o.FileProviders.Add(new EmbeddedFileProvider(typeof(HangfireJob).Assembly, "Webenable.Hangfire.Contrib")));
+
+            services.AddSingleton<IStartupFilter, HangfireTasksStartupFilter>();
+
+            return services;
+        }
+    }
+}

--- a/src/Webenable.Hangfire.Contrib/Webenable.Hangfire.Contrib.csproj
+++ b/src/Webenable.Hangfire.Contrib/Webenable.Hangfire.Contrib.csproj
@@ -20,6 +20,11 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.6.20" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Internal\HangfireTasks.cshtml" />
   </ItemGroup>
 </Project>

--- a/test/Webenable.Hangfire.Contrib.TestApp/Program.cs
+++ b/test/Webenable.Hangfire.Contrib.TestApp/Program.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Webenable.Hangfire.Contrib.TestApp
+{
+    public class Program
+    {
+        public static void Main(string[] args) => CreateWebHostBuilder(args).Build().Run();
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/test/Webenable.Hangfire.Contrib.TestApp/Properties/launchSettings.json
+++ b/test/Webenable.Hangfire.Contrib.TestApp/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:61711",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Webenable.Hangfire.Contrib.TestApp": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/test/Webenable.Hangfire.Contrib.TestApp/Startup.cs
+++ b/test/Webenable.Hangfire.Contrib.TestApp/Startup.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+using Hangfire.MemoryStorage;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Webenable.Hangfire.Contrib.TestApp
+{
+    public class FooTask
+    {
+        public Task ExecuteAsync(int fooId) => Task.CompletedTask;
+    }
+
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHangfireContrib(cfg => cfg.UseMemoryStorage())
+                    .AddHangfireTasksPage();
+            HangfireTaskRegister.AddTask<FooTask>(x => x.ExecuteAsync(default));
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Hello World!");
+            });
+        }
+    }
+}

--- a/test/Webenable.Hangfire.Contrib.TestApp/Webenable.Hangfire.Contrib.TestApp.csproj
+++ b/test/Webenable.Hangfire.Contrib.TestApp/Webenable.Hangfire.Contrib.TestApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
     <ProjectReference Include="..\..\src\Webenable.Hangfire.Contrib\Webenable.Hangfire.Contrib.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Webenable.Hangfire.Contrib.TestApp/Webenable.Hangfire.Contrib.TestApp.csproj
+++ b/test/Webenable.Hangfire.Contrib.TestApp/Webenable.Hangfire.Contrib.TestApp.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Hangfire.MemoryStorage.Core" Version="1.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <ProjectReference Include="..\..\src\Webenable.Hangfire.Contrib\Webenable.Hangfire.Contrib.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Webenable.Hangfire.Contrib.Tests/HangfireTasksPageTests.cs
+++ b/test/Webenable.Hangfire.Contrib.Tests/HangfireTasksPageTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Webenable.Hangfire.Contrib.Tests
+{
+    public class HangfireTasksPageTests : IClassFixture<WebApplicationFactory<TestApp.Startup>>
+    {
+        private readonly WebApplicationFactory<TestApp.Startup> _factory;
+
+        public HangfireTasksPageTests(WebApplicationFactory<TestApp.Startup> factory)
+        {
+            _factory = factory;
+        }
+
+        [Fact]
+        public async Task RendersTaskPage()
+        {
+            // Make sure the client is created, otherwise SendAync will null-ref
+            _ = _factory.CreateClient();
+
+            // Use SendAsync which allows us to configure the HttpContext
+            // so we can set the Remote IP address which the default Hangfire
+            // dashboard authorization uses to only allow local connections
+            var response = await _factory.Server.SendAsync(c =>
+            {
+                c.Request.Path = "/hangfire/tasks";
+                c.Connection.RemoteIpAddress = IPAddress.Loopback;
+            });
+
+            Assert.Equal(StatusCodes.Status200OK, response.Response.StatusCode);
+        }
+    }
+}

--- a/test/Webenable.Hangfire.Contrib.Tests/Webenable.Hangfire.Contrib.Tests.csproj
+++ b/test/Webenable.Hangfire.Contrib.Tests/Webenable.Hangfire.Contrib.Tests.csproj
@@ -5,9 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Webenable.Hangfire.Contrib\Webenable.Hangfire.Contrib.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <ProjectReference Include="..\Webenable.Hangfire.Contrib.TestApp\Webenable.Hangfire.Contrib.TestApp.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds a new navigation menu item pointing to the `/hangfire/tasks` page which shows available Hangfire tasks and allows to pass in values for primitive parameters and trigger the task. Tasks can be registered with `HangfireTaskRegister.AddTask<T>(...)`. 

For example, consider the following task:
```cs
public class FooTask
{
    public Task ExecuteAsync(int fooId) => Task.CompletedTask;
}
```

Which can be registered in the following way:
```cs
HangfireTaskRegister.AddTask<FooTask>(x => x.ExecuteAsync(default));
```